### PR TITLE
Use (thing-at-point 'symbol) instead of (thing-at-point 'word)

### DIFF
--- a/codesearch.el
+++ b/codesearch.el
@@ -87,7 +87,7 @@
 
 (defun codesearch-search-at-point ()
   (interactive)
-  (codesearch-search (thing-at-point 'word)))
+  (codesearch-search (thing-at-point 'symbol)))
 
 (defun codesearch-build-index (dir)
   "Scan DIR to rebuild an index."


### PR DESCRIPTION
Use `(thing-at-point 'symbol)` seems better because underscore, which is used very often in many programming languages, is not a word character in many default syntax tables, it seems.
