### PR TITLE
Use absolute directory path when creating index file

### DIFF
--- a/codesearch.el
+++ b/codesearch.el
@@ -188,7 +188,7 @@ BUFF is assumed to contain the output from running csearch.
   (interactive
    (list
     (read-directory-name "Directory: ")))
-  (codesearch--run-cindex dir))
+  (codesearch--run-cindex (expand-file-name dir)))
 
 ;;;###autoload
 (defun codesearch-update-index ()


### PR DESCRIPTION
If pass the directory path like '/home/user/~/' will lead to an error when creating the index file, the PR will solve this issue by using absolute path instead.