### PR TITLE
Fix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 ============
 
 The easy way to install `codesearch` is using the emacs package
-system. Just search [*melpa*](http://melpa.milkbox.net/#/) for "codesearch".
+system. Just search [*melpa*](https://melpa.org/) for "codesearch".
 
 Or you can do it manually. Copy codesearch.el to some location in your
 emacs load path. Then add `(require 'codesearch)` to your emacs

--- a/codesearch.el
+++ b/codesearch.el
@@ -148,7 +148,7 @@ BUFF is assumed to contain the output from running csearch.
     (beginning-of-buffer)
     (while (re-search-forward codesearch--match-regex nil t)
       (lexical-let* ((filename (match-string 1))
-                     (line-number (string-to-int (match-string 2)))
+                     (line-number (string-to-number (match-string 2)))
                      (visit-match (lambda (b)
                                     (find-file-other-window filename)
                                     (goto-line line-number))))

--- a/codesearch.el
+++ b/codesearch.el
@@ -65,6 +65,8 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl))
 (require 'dash)
 
 (defgroup codesearch nil


### PR DESCRIPTION
- Load cl.el for using `lexical-let*`
- Fix using deprecated function
- Update MELPA URL